### PR TITLE
fix(cli): accept Artifact downloads from a service subdomain

### DIFF
--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -2409,9 +2409,7 @@ fn validate_url(url: &Url, allowed: &AllowedOrigin) -> Result<(), RemoteError> {
     }
     let allowed = match allowed {
         AllowedOrigin::Service(base) => same_origin(url, base),
-        AllowedOrigin::Artifact(base) => {
-            same_origin(url, base) || is_https_subdomain_of(url, base)
-        }
+        AllowedOrigin::Artifact(base) => same_origin(url, base) || is_https_subdomain_of(url, base),
         AllowedOrigin::Github => {
             url.scheme() == "https"
                 && url.host_str() == Some("api.github.com")

--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -1098,7 +1098,7 @@ impl SkilldRemote {
             body: vec![],
             response_limit: limit,
         };
-        self.execute(request, AllowedOrigin::Service(self.endpoint.clone()))
+        self.execute(request, AllowedOrigin::Artifact(self.endpoint.clone()))
             .map(|response| response.body)
     }
 
@@ -2371,7 +2371,27 @@ fn invalid_update_response() -> RemoteError {
 #[derive(Clone)]
 enum AllowedOrigin {
     Service(Url),
+    /// Artifact bytes come from the service origin or from one of its
+    /// subdomains, such as `artifacts.skilld.dev` for `skilld.dev`.
+    Artifact(Url),
     Github,
+}
+
+fn same_origin(url: &Url, base: &Url) -> bool {
+    url.scheme() == base.scheme()
+        && url.host_str() == base.host_str()
+        && url.port_or_known_default() == base.port_or_known_default()
+}
+
+fn is_https_subdomain_of(url: &Url, base: &Url) -> bool {
+    let (Some(host), Some(base_host)) = (url.host_str(), base.host_str()) else {
+        return false;
+    };
+    url.scheme() == "https"
+        && url.port().is_none()
+        && host
+            .strip_suffix(base_host)
+            .is_some_and(|prefix| prefix.len() > 1 && prefix.ends_with('.'))
 }
 
 fn validate_request_url(value: &str, allowed: &AllowedOrigin) -> Result<(), RemoteError> {
@@ -2388,10 +2408,9 @@ fn validate_url(url: &Url, allowed: &AllowedOrigin) -> Result<(), RemoteError> {
         ));
     }
     let allowed = match allowed {
-        AllowedOrigin::Service(base) => {
-            url.scheme() == base.scheme()
-                && url.host_str() == base.host_str()
-                && url.port_or_known_default() == base.port_or_known_default()
+        AllowedOrigin::Service(base) => same_origin(url, base),
+        AllowedOrigin::Artifact(base) => {
+            same_origin(url, base) || is_https_subdomain_of(url, base)
         }
         AllowedOrigin::Github => {
             url.scheme() == "https"

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -1746,6 +1746,60 @@ fn a_verified_remote_install_uses_resolution_root_grant_and_content_in_order() {
 }
 
 #[test]
+fn a_public_grant_may_serve_content_from_a_service_subdomain() {
+    let (pin, mut responses) = verified_remote_responses();
+    let mut grant: serde_json::Value = serde_json::from_slice(&responses[2].body).unwrap();
+    grant["contentUrl"] = json!("https://artifacts.skilld.dev/sha256/example");
+    responses[2] = response(200, serde_json::to_vec(&grant).unwrap());
+    let http = Arc::new(FakeHttp::with(responses));
+    let remote = SkilldRemote::new(
+        http.clone(),
+        Arc::new(NoTokenProvider),
+        NativeRemoteConfig::Pinned(pin),
+    )
+    .with_endpoint("https://skilld.dev")
+    .unwrap()
+    .with_sleeper(Arc::new(NoSleep));
+    let selector = RemoteSelector::parse("skilld:skilld-dev/skills/example").unwrap();
+
+    let prepared = remote.prepare(&selector, false).unwrap();
+
+    assert!(matches!(
+        prepared.source_status,
+        SourceStatus::Verified { .. }
+    ));
+    let requests = http.requests.lock().unwrap();
+    assert_eq!(requests.len(), 4);
+    assert_eq!(
+        requests[3].url,
+        "https://artifacts.skilld.dev/sha256/example"
+    );
+}
+
+#[test]
+fn a_public_grant_on_an_unrelated_origin_is_rejected_before_download() {
+    let (pin, mut responses) = verified_remote_responses();
+    let mut grant: serde_json::Value = serde_json::from_slice(&responses[2].body).unwrap();
+    grant["contentUrl"] = json!("https://example.com/sha256/example");
+    responses[2] = response(200, serde_json::to_vec(&grant).unwrap());
+    let http = Arc::new(FakeHttp::with(responses));
+    let remote = SkilldRemote::new(
+        http.clone(),
+        Arc::new(NoTokenProvider),
+        NativeRemoteConfig::Pinned(pin),
+    )
+    .with_endpoint("https://skilld.dev")
+    .unwrap()
+    .with_sleeper(Arc::new(NoSleep));
+    let selector = RemoteSelector::parse("skilld:skilld-dev/skills/example").unwrap();
+
+    let error = remote.prepare(&selector, false).unwrap_err();
+
+    assert_eq!(error.code, "REMOTE_ORIGIN_REJECTED");
+    assert_eq!(http.requests.lock().unwrap().len(), 3);
+}
+
+#[test]
 fn a_private_artifact_download_sends_the_account_and_one_time_grant() {
     let (pin, mut responses) = verified_remote_responses();
     let public_grant: serde_json::Value = serde_json::from_slice(&responses[2].body).unwrap();


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Every `skilld:` run and install on 3.0.0-beta.4 dies at the last hop:

```
$ skilld run skilld:tt-a1i/archify/archify
REMOTE_ORIGIN_REJECTED: the remote URL uses an unapproved origin
```

The resolution, trusted root, and grant all succeed. The grant then points at `https://artifacts.skilld.dev/...`, which skilld.dev has served since skilld-dev/skilld.dev#54, and the CLI only allows the API origin itself. The tests never caught it because the fake grant sits on the same `127.0.0.1:8787` origin as the API.

A grant may now point at the service origin or at an https subdomain of it. Anything else is still refused before the request leaves.

I went with the subdomain rule rather than a hard coded `artifacts.skilld.dev` so a staging endpoint keeps working. Open to pinning the host in the trusted root instead if you would rather the service name it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01ASGK6drkuCbo7vsPQcYCvn