### PR TITLE
fix(cli): name the GitHub rate limit on a direct run

### DIFF
--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -852,7 +852,10 @@ impl SkilldRemote {
                 continue;
             }
             if !(200..300).contains(&response.status) {
-                return Err(problem_error(&response));
+                return Err(match allowed {
+                    AllowedOrigin::Github => github_error(&response),
+                    AllowedOrigin::Service(_) => problem_error(&response),
+                });
             }
             return Ok(response);
         }
@@ -2484,6 +2487,19 @@ fn problem_error(response: &HttpResponse) -> RemoteError {
             RemoteError::new(problem_code(&problem.code), detail)
         },
     )
+}
+
+fn github_error(response: &HttpResponse) -> RemoteError {
+    if !is_rate_limited(response) {
+        return service_unavailable_error(response);
+    }
+    let detail = match bounded_rate_limit_wait(response) {
+        Some(seconds) => {
+            format!("GitHub rate limited this request. Retry after {seconds} seconds.")
+        }
+        None => "GitHub rate limited this request. Retry in a minute.".to_owned(),
+    };
+    RemoteError::new("RATE_LIMITED", detail)
 }
 
 fn service_unavailable_error(response: &HttpResponse) -> RemoteError {

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -1847,6 +1847,36 @@ fn direct_github_access_resolves_an_exact_public_commit_without_tokens() {
 }
 
 #[test]
+fn a_direct_github_rate_limit_names_github_and_the_reset_wait() {
+    let reset = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 300;
+    let mut limited = response(403, br#"{"message":"API rate limit exceeded"}"#.to_vec());
+    limited
+        .headers
+        .insert("x-ratelimit-remaining".to_owned(), "0".to_owned());
+    limited
+        .headers
+        .insert("x-ratelimit-reset".to_owned(), reset.to_string());
+    let http = Arc::new(FakeHttp::with([limited]));
+    let remote = SkilldRemote::new(
+        http.clone(),
+        Arc::new(NoTokenProvider),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_sleeper(Arc::new(NoSleep));
+    let selector = RemoteSelector::parse("github:skilld-dev/skills/skills/example").unwrap();
+
+    let error = remote.prepare(&selector, true).unwrap_err();
+
+    assert_eq!(error.code, "RATE_LIMITED");
+    assert!(error.message.starts_with("GitHub rate limited this request. Retry after "));
+    assert_eq!(http.requests.lock().unwrap().len(), 1);
+}
+
+#[test]
 fn prepare_exact_rejects_a_conflicting_selector_commit_before_http() {
     let selector_commit = "0123456789abcdef0123456789abcdef01234567";
     let expected_commit = CommitSha::parse("ffffffffffffffffffffffffffffffffffffffff").unwrap();

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -1872,7 +1872,11 @@ fn a_direct_github_rate_limit_names_github_and_the_reset_wait() {
     let error = remote.prepare(&selector, true).unwrap_err();
 
     assert_eq!(error.code, "RATE_LIMITED");
-    assert!(error.message.starts_with("GitHub rate limited this request. Retry after "));
+    assert!(
+        error
+            .message
+            .starts_with("GitHub rate limited this request. Retry after ")
+    );
     assert_eq!(http.requests.lock().unwrap().len(), 1);
 }
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`--direct` sends anonymous requests to GitHub, so a shared machine burns the 60 per hour quota fast. When it does, the CLI blames the wrong service and gives no wait:

```
$ skilld run github:tt-a1i/archify/archify --direct
SERVICE_UNAVAILABLE: the remote service returned HTTP 403
```

Now:

```
RATE_LIMITED: GitHub rate limited this request. Retry after 2843 seconds.
```

The update comparison path already recognised this response; direct runs and restores now do too.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01ASGK6drkuCbo7vsPQcYCvn